### PR TITLE
Refactor: Migrate to declarativeNetRequest

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,13 +1,14 @@
 ## TODO
 [] CI: RELEASE patch version 1.0.1 with the latest changes.
-[] CI: Create a script that uses the CWS API to submit a new version. This should support a "dry run" for testing. Write tests for the script. It should also push a tagged commit with the version number matching the npm and manifest version that has been bumped.
 
 ## DELEGATED
-[] CI: improve unit and e2e test coverage
+[] CI: Create a script that uses the CWS API to submit a new version. This should support a "dry run" for testing. Write tests for the script. It should also push a tagged commit with the version number matching the npm and manifest version that has been bumped. Please do not actually version up the extension while testing.
 
 ## DOING
+[] FEATURE: Create extension docs homepage on github pages: https://jordanblakey.github.io/url-redirector/. Enable github issues, link as contact. Need privacy policy. Need verification meta tag.
 
 ## DONE
+[x]: migrate from a listener-based approach to declarativeNetRequest (DNR) to improve performance and remove the tabs permission (to avoid the "Read History" warning).
 [x] CI: Push initial version through Chrome Web Store review process
 [x] FEATURE: Favicon caching mechanism (why? Browser caching...)
 [x] BUG: "Active Rules" is a bit misleading with new pause/resume feature. "Redirection Rules"? "Rules"?

--- a/manifest.json
+++ b/manifest.json
@@ -5,8 +5,10 @@
   "description": "Redirects URLs based on user-defined rules.",
   "permissions": [
     "storage",
-    "webNavigation",
-    "tabs"
+    "declarativeNetRequestWithHostAccess"
+  ],
+  "host_permissions": [
+    "*://*/*"
   ],
   "options_page": "assets/html/options.html",
   "icons": {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -70,3 +70,20 @@ export function isValidUrl(string: string): boolean {
         return false;
     }
 }
+
+/**
+ * Generates a consistent integer ID from a URL string.
+ * Used for declarativeNetRequest rule IDs.
+ * @param url The URL string to hash.
+ * @returns A positive integer ID.
+ */
+export function generateRuleId(url: string): number {
+    let hash = 0;
+    if (url.length === 0) return hash;
+    for (let i = 0; i < url.length; i++) {
+        const char = url.charCodeAt(i);
+        hash = ((hash << 5) - hash) + char;
+        hash = hash & hash; // Convert to 32bit integer
+    }
+    return Math.abs(hash);
+}

--- a/test/e2e/immediate-redirect.spec.ts
+++ b/test/e2e/immediate-redirect.spec.ts
@@ -102,4 +102,27 @@ test.describe('Immediate Redirect on Rule Change', () => {
         // Verify redirect
         await expect(page).toHaveURL(/google\.com/);
     });
+
+    test('should redirect new tabs using DNR rules', async ({ context }) => {
+        const worker = context.serviceWorkers()[0] || await context.waitForEvent('serviceworker');
+
+        // Add rule
+        await worker.evaluate(async () => {
+            const rules = [{
+                source: 'example.edu',
+                target: 'google.com',
+                active: true,
+                count: 0,
+                id: 126
+            }];
+            await chrome.storage.local.set({ rules });
+        });
+
+        // Open a NEW tab to the source URL
+        const page = await context.newPage();
+        await page.goto('https://example.edu');
+
+        // Verify redirect
+        await expect(page).toHaveURL(/google\.com/);
+    });
 });


### PR DESCRIPTION
Migrates the extension from \`webNavigation\` to \`declarativeNetRequest\` (DNR) to improve performance and remove the \`tabs\` permission warning. Preserves the 'Sweeper' functionality (immediate redirect of open tabs) using \`host_permissions\`.